### PR TITLE
build: Set Java version to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   </parent>
 
   <properties>
-    <java.version>17</java.version>
+    <!-- release parent settings -->
+    <version.java>17</version.java>
     <feel.version>1.16.1</feel.version>
     <spring.boot.version>3.1.1</spring.boot.version>
   </properties>


### PR DESCRIPTION
## Description

Set the Java version (in the parent POM) to 17. Previously, it sets the version in the wrong property.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

