### PR TITLE
fix: Return temporal values in FEEL-compatible format

### DIFF
--- a/src/main/java/org/camunda/feel/playground/sevice/FeelEvaluationService.java
+++ b/src/main/java/org/camunda/feel/playground/sevice/FeelEvaluationService.java
@@ -8,10 +8,16 @@
 package org.camunda.feel.playground.sevice;
 
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
 import org.camunda.feel.FeelEngine;
 import org.camunda.feel.api.EvaluationResult;
 import org.camunda.feel.api.FeelEngineApi;
 import org.camunda.feel.impl.JavaValueMapper;
+import org.camunda.feel.syntaxtree.*;
+import org.camunda.feel.valuemapper.CustomValueMapper;
+import org.camunda.feel.valuemapper.JavaCustomValueMapper;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,7 +27,9 @@ public final class FeelEvaluationService {
 
   private FeelEngineApi buildFeelEngine() {
     final var feelEngine =
-        new FeelEngine.Builder().customValueMapper(new JavaValueMapper()).build();
+        new FeelEngine.Builder()
+            .customValueMapper(new JavaValueMapperWithTemporalStringDeserialization())
+            .build();
     return new FeelEngineApi(feelEngine);
   }
 
@@ -32,5 +40,37 @@ public final class FeelEvaluationService {
   public EvaluationResult evaluateUnaryTests(
       String expression, Object inputValue, Map<String, Object> context) {
     return feelEngineApi.evaluateUnaryTests(expression, inputValue, context);
+  }
+
+  private static class JavaValueMapperWithTemporalStringDeserialization
+      extends JavaCustomValueMapper {
+
+    private final CustomValueMapper baseValueMapper = new JavaValueMapper();
+
+    @Override
+    public Optional<Val> toValue(Object x, Function<Object, Val> innerValueMapper) {
+      return baseValueMapper.toVal(x, innerValueMapper::apply).fold(Optional::empty, Optional::of);
+    }
+
+    @Override
+    public Optional<Object> unpackValue(Val value, Function<Val, Object> innerValueMapper) {
+      if (isTemporalValue(value)) {
+        return Optional.of(value.toString());
+      } else {
+        return baseValueMapper
+            .unpackVal(value, innerValueMapper::apply)
+            .fold(Optional::empty, Optional::of);
+      }
+    }
+
+    private static boolean isTemporalValue(Val value) {
+      return value instanceof ValDate
+          || value instanceof ValTime
+          || value instanceof ValLocalTime
+          || value instanceof ValDateTime
+          || value instanceof ValLocalDateTime
+          || value instanceof ValDayTimeDuration
+          || value instanceof ValYearMonthDuration;
+    }
   }
 }

--- a/src/test/java/org/camunda/feel/playground/FeelApiTest.java
+++ b/src/test/java/org/camunda/feel/playground/FeelApiTest.java
@@ -13,6 +13,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,34 +38,33 @@ public final class FeelApiTest {
         .andExpect(content().json("{'result': 3}"));
   }
 
-  @Test
-  void shouldReturnNull() throws Exception {
+  @CsvSource(
+      value = {
+        "3;3",
+        "\\\"feel\\\";\"feel\"",
+        "true;true",
+        "null;null",
+        "[1,2,3];[1,2,3]",
+        "{x:1};{'x': 1}",
+        "[{x:1}];[{'x': 1}]",
+        "{x:[1,2]};{'x': [1,2]}",
+        "@\\\"2025-01-20\\\";\"2025-01-20\"",
+        "@\\\"10:41:30\\\";\"10:41:30\"",
+        "@\\\"10:41:30+02:00\\\";\"10:41:30+02:00\"",
+        "@\\\"2025-01-20T10:41:30\\\";\"2025-01-20T10:41:30\"",
+        "@\\\"2025-01-20T10:41:30+02:00\\\";\"2025-01-20T10:41:30+02:00\"",
+        "@\\\"P5D\\\";\"P5D\"",
+        "@\\\"P2Y\\\";\"P2Y\""
+      },
+      delimiter = ';')
+  @ParameterizedTest
+  void shouldReturnResultValue(final String expression, final String expected) throws Exception {
     mvc.perform(
             post("/api/v1/feel/evaluate")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"expression\": \"null\", \"context\": {}}"))
+                .content("{\"expression\": \"" + expression + "\", \"context\": {}}"))
         .andExpect(status().isOk())
-        .andExpect(content().json("{'result': null}"));
-  }
-
-  @Test
-  void shouldReturnList() throws Exception {
-    mvc.perform(
-            post("/api/v1/feel/evaluate")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"expression\": \"[1,2,3]\", \"context\": {}}"))
-        .andExpect(status().isOk())
-        .andExpect(content().json("{'result': [1,2,3]}"));
-  }
-
-  @Test
-  void shouldReturnContext() throws Exception {
-    mvc.perform(
-            post("/api/v1/feel/evaluate")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"expression\": \"{x:1}\", \"context\": {}}"))
-        .andExpect(status().isOk())
-        .andExpect(content().json("{'result': {'x': 1}}"));
+        .andExpect(content().json("{'result': " + expected + "}"));
   }
 
   @Test


### PR DESCRIPTION
## Description

Return FEEL duration values and other temporal values in the string format of the FEEL engine. 

## Related issues

closes #86 