### PR TITLE
feat: Change Mixpanel server URL

### DIFF
--- a/src/main/java/org/camunda/feel/playground/sevice/MixpanelTrackingService.java
+++ b/src/main/java/org/camunda/feel/playground/sevice/MixpanelTrackingService.java
@@ -16,7 +16,9 @@ public class MixpanelTrackingService implements TrackingService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MixpanelTrackingService.class);
 
-  private final MixpanelAPI mixpanelAPI = new MixpanelAPI();
+  private static final String MIXPANEL_API_URL = "https://api-eu.mixpanel.com";
+
+  private final MixpanelAPI mixpanelAPI = new MixpanelAPI(MIXPANEL_API_URL + "/track", MIXPANEL_API_URL + "/engage");
 
   private final MessageBuilder messageBuilder;
 


### PR DESCRIPTION
## Description

Use the Mixpanel EU server.

Related to https://docs.mixpanel.com/changelogs#deprecation-notice-legacy-us-to-eu-data-forwarding-ends-july-2026-for-eu-projects

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->
